### PR TITLE
(#4) BREAKING: Modify characteristics monitoring stream to be a single subscriber stream

### DIFF
--- a/lib/src/bridge/characteristics_mixin.dart
+++ b/lib/src/bridge/characteristics_mixin.dart
@@ -278,7 +278,7 @@ mixin CharacteristicsMixin on FlutterBLE {
                 CancelOnErrorStreamTransformer());
 
     StreamController<CharacteristicWithValueAndTransactionId> streamController =
-        StreamController.broadcast(
+        StreamController(
       onListen: onListen,
       onCancel: () => cancelTransaction(transactionId),
     );


### PR DESCRIPTION
Breaking change - modify the stream returned from monitoring a characteristic to be a single subscriber stream rather than a broadcast stream. This allows the cancellation of the stream to complete with a Future and properly clean up resources to avoid a race condition as described in (#4).