### PR TITLE
Bump compile sdk to 34 and use new namespace syntax

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,10 +23,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    namespace 'com.polidea.flutter_ble_lib'
+    compileSdk 34
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 23
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.polidea.flutter_ble_lib">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/lib/src/_internal.dart
+++ b/lib/src/_internal.dart
@@ -2,8 +2,6 @@ library _internal;
 
 import 'dart:async';
 import 'dart:convert';
-// This is included in foundation in newer flutter versions, but not in olders ones (eg, 2.8.1)
-import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';


### PR DESCRIPTION
Compatibility with latest Play Store requirements, as well as newer gradle version requirements.