### PR TITLE
Downgrad multiplatformbleadapter back to 0.1.8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,5 +37,5 @@ android {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'com.github.dotintent:MultiPlatformBleAdapter:0.2.0'
+    implementation 'com.github.dotintent:MultiPlatformBleAdapter:0.1.8'
 }

--- a/ios/flutter_ble_lib.podspec
+++ b/ios/flutter_ble_lib.podspec
@@ -16,7 +16,7 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h' 
   s.dependency 'Flutter'
   s.swift_versions = ['4.0', '4.2', '5.0']
-  s.dependency 'MultiplatformBleAdapter', '~> 0.2.0'
+  s.dependency 'MultiplatformBleAdapter', '~> 0.1.8'
 
   s.ios.deployment_target = '8.0'
 end


### PR DESCRIPTION
0.2.0 brings in a newer version of RxJava but doesn't handle exceptions properly (https://github.com/ReactiveX/RxJava/wiki/What's-different-in-2.0#error-handling)